### PR TITLE
Updating to reference byu-calendar component

### DIFF
--- a/main-config.yml
+++ b/main-config.yml
@@ -7,6 +7,8 @@ byu-theme-components:
   source: github:byuweb/byu-theme-components
 byu-card:
   source: github:byuweb/byu-card
+byu-calendar:
+  source: github:byuweb/byu-calendar-component
 byu-calendar-row:
   source: github:byuweb/byu-calendar-row
 byu-calendar-tile:


### PR DESCRIPTION
I created a byu-calendar component to reduce the amount of code needed to use the byu-calendar widget. Right now it just wraps the byu-calendar-row and byu-calendar-tile components, but with some cleanup it could eventually be used to reduce or eliminate the need to use them as dependencies.