### PR TITLE
Updating to target byu-calendar-components

### DIFF
--- a/main-config.yml
+++ b/main-config.yml
@@ -11,15 +11,15 @@ libraries:
   byu-calendar-components:
     source: github:byuweb/byu-calendar-components
 
-# depracated in favor of byu-calendar-components -included only for backwards compatibility
+# deprecated in favor of byu-calendar-components -included only for backwards compatibility
   byu-calendar-row:
     source: github:byuweb/byu-calendar-row
 
-# depracated in favor of byu-calendar-components -included only for backwards compatibility
+# deprecated in favor of byu-calendar-components -included only for backwards compatibility
   byu-calendar-tile:
     source: github:byuweb/byu-calendar-tile
 
-web-component-polyfills:
+  web-component-polyfills:
     source: github:byuweb/web-component-polyfills
 #    source: npm:@webcomponents/webcomponentsjs
 #    configuration:

--- a/main-config.yml
+++ b/main-config.yml
@@ -8,11 +8,18 @@ libraries:
     source: github:byuweb/byu-theme-components
   byu-card:
     source: github:byuweb/byu-card
+  byu-calendar-components:
+    source: github:byuweb/byu-calendar-components
+
+# depracated in favor of byu-calendar-components -included only for backwards compatibility
   byu-calendar-row:
     source: github:byuweb/byu-calendar-row
+
+# depracated in favor of byu-calendar-components -included only for backwards compatibility
   byu-calendar-tile:
     source: github:byuweb/byu-calendar-tile
-  web-component-polyfills:
+
+web-component-polyfills:
     source: github:byuweb/web-component-polyfills
 #    source: npm:@webcomponents/webcomponentsjs
 #    configuration:


### PR DESCRIPTION
Updating to target byu-calendar-components. 

@michaelpratt28 has bundled the byu-calendar-row and byu-calendar-tile components into a single repository, along with a byu-calendar component that wraps both of them and makes the necessary AJAX calls. To prevent duplicate work I'm proposing that we shut down the byu-calendar-row and byu-calendar-tile repos, but leave the existing releases of each one on the CDN for backwards compatibility.